### PR TITLE
ci: enforce commit message standards with commitlint

### DIFF
--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,0 +1,24 @@
+// Defined rules on commit messages; see the docs: https://commitlint.js.org/#/reference-rules
+
+const TypesArray = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"];
+const SubjectsArray = ["upper-case", "pascal-case", "sentence-case", "start-case"];
+
+const Configuration = {
+  rules: {
+    "type-enum": [2, "always", TypesArray],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "scope-case": [2, "always", "kebab-case"],
+    "subject-case": [2, "never", SubjectsArray],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "header-max-length": [2, "always", 80],
+    "body-case": [2, "always", "sentence-case"],
+    "body-leading-blank": [2, "always"],
+    "body-max-line-length": [2, "always", 100],
+    "footer-leading-blank": [2, "always"],
+    "footer-max-line-length": [2, "always", 100],
+  },
+};
+
+module.exports = Configuration;

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,23 @@
+name: Lint Commit Messages
+
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    name: Commitlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .github/commitlint.config.js


### PR DESCRIPTION
Implemented a _commitlint_ configuration and a _GitHub Actions Workflow_ to ensure that commit messages adhere to predefined standards, enhancing the readability and maintainability of our codebase.

Commit types and scope cases are enforced, with rules set for header, body, and footer formats.

Valid commit messages must be all lowercase and other specific rules, like this `feat: valid commit message` example. To customize formatting like using `feat: Valid commit message`, follow the defined rules for `subject-case` options in the `commitlint.config.js` file, specifically the setting `"subject-case": [2, "always", "sentence-case"]`.

These changes automatically validate incoming pull requests for consistent commit message structure.