### PR TITLE
chore: update code styles and expand `.gitignore`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,13 +9,13 @@ indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-max_line_length = 120
 quote_type = double
 
-[*.{commitlintrc,eslint*,js,jsx,json,md,mjs,ts,tsx}]
+[*.{commitlintrc,eslint*,html,css,js,jsx,json,md,mjs,ts,tsx,versionrc,todo}]
 indent_size = 2
+max_line_length = 120
 
-[*.{html,yml,yaml}]
+[*.{yml,yaml}]
 indent_size = 2
 max_line_length = off
 
@@ -25,13 +25,20 @@ max_line_length = 115
 [*.py]
 profile = black
 
-[*.{sh,bash,zsh}]
+[*.{sh,bash,zsh*,vim}]
 indent_size = 2
-max_line_length = 79
+max_line_length = 80
 
 [{*.svg,.env*}]
 insert_final_newline = false
 max_line_length = off
+
+[{.clang-format,.clang-tidy}]
+indent_size = 2
+
+[{CMakeLists.txt,*.{cmake,c,h,cc,hh,cpp,hpp,cxx,hxx}}]
+indent_size = 2
+max_line_length = 80
 
 [{Makefile,.gitattributes,.gitconfig,.gitcredentials,.gitmessage,.gitmodules}]
 indent_size = 8

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Defined base templates
 
+#-----------------------------------------------------------------------------------------------------------------------
 # .gitignore template: Python
+#-----------------------------------------------------------------------------------------------------------------------
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -162,8 +164,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-
+#-----------------------------------------------------------------------------------------------------------------------
 # .gitignore template: Node
+#-----------------------------------------------------------------------------------------------------------------------
 # Logs
 logs
 *.log
@@ -211,8 +214,9 @@ jspm_packages/
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/
 
-# TypeScript cache
+# Typescript
 *.tsbuildinfo
+next-env.d.ts
 
 # Optional npm cache directory
 .npm
@@ -295,8 +299,85 @@ dist
 .yarn/install-state.gz
 .pnp.*
 
+#-----------------------------------------------------------------------------------------------------------------------
+# .gitignore template: CMake
+#-----------------------------------------------------------------------------------------------------------------------
+# Files and directories
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+**/Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+build
 
+#-----------------------------------------------------------------------------------------------------------------------
+# .gitignore template: C and C++
+#-----------------------------------------------------------------------------------------------------------------------
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+*.slo
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lai
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.smod
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+#-----------------------------------------------------------------------------------------------------------------------
 # .gitignore template: MDSANIMA
+#-----------------------------------------------------------------------------------------------------------------------
 # Python setuptools_scm version
 _version.py
 


### PR DESCRIPTION
EditorConfig now applies a consistent line length of 120 characters to most code files and includes additional file types for specific indentation rules. Vim script files have also been addressed with an indentation size of 2 and max line length adjustment to 80. C and C++ along with CMake related ignores are added to `.gitignore`, enhancing the cleanliness of the repository. Additionally, visual separators in `.gitignore` clarify the file's structure.

This aligns with modern coding standards and maintains the repository's cleanliness.